### PR TITLE
Fixed crash for bluetooth devices without name (e.g. Garmin watches)

### DIFF
--- a/app/src/main/java/com/borconi/emil/wifilauncherforhur/activities/MainPreferenceFragment.java
+++ b/app/src/main/java/com/borconi/emil/wifilauncherforhur/activities/MainPreferenceFragment.java
@@ -182,6 +182,12 @@ public class MainPreferenceFragment extends PreferenceFragmentCompat {
         if (adapter != null && adapter.getBondedDevices().size() > 0) {
             entries = adapter.getBondedDevices().stream().map(BluetoothDevice::getName).toArray(String[]::new);
             entryValues = adapter.getBondedDevices().stream().map(BluetoothDevice::getAddress).toArray(String[]::new);
+            for (int i=0; i<entries.length; i++) {
+                if (entries[i] == null) {
+                    // Workaround for bluetooth devices without name
+                    entries[i] = entryValues[i];
+                }
+            }
         }
 
         preference.setEntries(entries);


### PR DESCRIPTION
This fixes the issue #14. Tested on my Google Pixel 5 and it works now without any problem. Please merge this commit